### PR TITLE
Removing the get_md5_hash method out of the describe method. This is …

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,18 @@ To use pistachio you can inport the module by running the following commands.
 Method to return a description for the resource.
 
 ```python
->>> pistachio.describe("README.md")
-{"path": "README.md", "exists": True, "is_directory": False, "is_file": True, "is_symlink": False, "name": "README.md", "md5": "2f853812babf98322618edeb24359591"}
+>>> print(json.dumps(pistachio.describe("README.md"), sort_keys=2, indent=2))
+{
+  "exists": true,
+  "is_directory": false,
+  "is_file": true,
+  "is_symlink": false,
+  "name": "README.md",
+  "path": "README.md"
+}
 ```
+
+print(json.dumps(pistachio.tree("src"), sort_keys=2, indent=2))
 
 ### Exists
 
@@ -102,7 +111,6 @@ This method will return a list of directories, files and symlinks below a specif
       "is_directory": false,
       "is_file": true,
       "is_symlink": false,
-      "md5": "d41d8cd98f00b204e9800998ecf8427e",
       "name": "__init__.py",
       "path": "./__init__.py"
     },
@@ -111,7 +119,6 @@ This method will return a list of directories, files and symlinks below a specif
       "is_directory": false,
       "is_file": true,
       "is_symlink": false,
-      "md5": "fdf4baea582e9b6198904292429a2d00",
       "name": "pistachio.py",
       "path": "./pistachio.py"
     }

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="pistachio",
-    version="0.1.0",
+    version="0.1.1",
     description="Pistachio aims to simplify reoccurring tasks when working with the file system.",
     py_modules=["pistachio"],
     package_dir={"": "src"},

--- a/src/pistachio.py
+++ b/src/pistachio.py
@@ -16,8 +16,7 @@ def describe(path_str):
         "is_directory": is_directory(path_str),
         "is_file": is_file(path_str),
         "is_symlink": is_symlink(path_str),
-        "name": path_str.split("/")[-1],
-        "md5": get_md5_hash(path_str)
+        "name": path_str.split("/")[-1]
     }
 
 

--- a/tests/test_pistachio.py
+++ b/tests/test_pistachio.py
@@ -19,7 +19,6 @@ DESCRIBE_SCHEMA = Schema({
     "is_directory": And(Use(bool)),
     "is_file": And(Use(bool)),
     "is_symlink": And(Use(bool)),
-    "md5": And(Use(str)),
     "name": And(Use(str))
 })
 
@@ -79,8 +78,7 @@ def tree_expected_results():
                 "is_directory": False,
                 "is_file": True,
                 "is_symlink": False,
-                "name": "file-1.txt",
-                "md5": "d41d8cd98f00b204e9800998ecf8427e"
+                "name": "file-1.txt"
             },
             {
                 "path": "./file-2.txt",
@@ -88,8 +86,7 @@ def tree_expected_results():
                 "is_directory": False,
                 "is_file": False,
                 "is_symlink": True,
-                "name": "file-2.txt",
-                "md5": None
+                "name": "file-2.txt"
             },
             {
                 "path": "./xyz",
@@ -97,8 +94,7 @@ def tree_expected_results():
                 "is_directory": True,
                 "is_file": False,
                 "is_symlink": False,
-                "name": "xyz",
-                "md5": None
+                "name": "xyz"
             },
             {
                 "path": "./xyz/file-3.txt",
@@ -106,8 +102,7 @@ def tree_expected_results():
                 "is_directory": False,
                 "is_file": True,
                 "is_symlink": False,
-                "name": "file-3.txt",
-                "md5": "d41d8cd98f00b204e9800998ecf8427e"
+                "name": "file-3.txt"
             },
             {
                 "path": "./xyz/file-4.txt",
@@ -115,8 +110,7 @@ def tree_expected_results():
                 "is_directory": False,
                 "is_file": True,
                 "is_symlink": False,
-                "name": "file-4.txt",
-                "md5": "d41d8cd98f00b204e9800998ecf8427e"
+                "name": "file-4.txt"
             }
         ]
     }, sort_keys = True)


### PR DESCRIPTION
Removing the "get_md5_hash" method out of the "describe" method. This is to optimise for speed handling large files.